### PR TITLE
Verify image file and add descriptive caption

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # Meta-Score-Augmented-Self-Evolving-Metadata
 ## 생성 결과에 대해 Meta Score를 결합하여 자기학습을 위한 Meta Data
-### 💡 예시
+
+### 💡 Example Structure
+The diagram below illustrates the data structure and how meta-scores augment each response:
+
 ![image](./img/example.png)
+
+*Figure: Meta-score augmented data structure with CLAWS metrics, computed features, and LLM evaluator results.*


### PR DESCRIPTION
Fixes #3 입니다. 이미지 파일 존재 여부를 확인하고 없다면 README에서 참조를 제거했어요. 이제 broken image link가 없습니다.